### PR TITLE
Fix player playback thread issue

### DIFF
--- a/app/src/main/java/com/telehub/telehubapp/MainActivity.kt
+++ b/app/src/main/java/com/telehub/telehubapp/MainActivity.kt
@@ -112,8 +112,10 @@ class MainActivity : ComponentActivity() {
 
                                 ChannelCard(name = name) {
                                     client.createLink(viewModel.token, cmd) { streamUrl ->
-                                        playerManager.play(streamUrl)
-                                        setContentView(playerManager.getPlayerView())
+                                        runOnUiThread {
+                                            playerManager.play(streamUrl)
+                                            setContentView(playerManager.getPlayerView())
+                                        }
                                     }
 
                                 }


### PR DESCRIPTION
## Summary
- fix stream playback callback to run on UI thread

## Testing
- `./gradlew build --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68401ae95794832f95e4b7cc5e004459